### PR TITLE
add 'current_eq' to User model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -145,6 +145,7 @@ model User {
   totalEqMatches      Int                   @default(0)
   totalEqMatchesWon   Int                   @default(0)
   totalEqMatchesLost  Int?                  @default(0)
+  current_eq          String?               @db.Uuid
   Account             Account[]
   Equation            Equation[]
   Session             Session[]


### PR DESCRIPTION
- Added the current_eq property to User to store the id of the equation that is currently selected to use in ranked matches