### PR TITLE
fix for upsertUser

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -191,7 +191,6 @@ export async function upsertUser(data: User) {
         current_eq_id: data.current_eq_id || undefined,
       },
       update: {
-        name: data.name || undefined,
         email: data.email || undefined,
         epic_id: data.epic_id || undefined,
         discord_id: data.discord_id || undefined,


### PR DESCRIPTION
- Trying to fix `upsertUser()` requiring the `User.name` field during a record update